### PR TITLE
Fix tsserver

### DIFF
--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -13,4 +13,4 @@ jobs:
         uses: nebularg/actions-luacheck@v1
         with:
           # args: init.lua lua/bindings.lua --globals vim
-          args: init.lua --globals vim
+          args: init.lua --globals vim tsserver

--- a/init.lua
+++ b/init.lua
@@ -332,7 +332,7 @@ require('lazy').setup({
       local servers = {
         yamlls = {},
         ansiblels = {},
-        ts_ls = 'tsserver',
+        ts_ls = tsserver,
         pyright = {},
         rust_analyzer = {},
         lua_ls = {


### PR DESCRIPTION
ok, so nvim need no quotes, but the linter did not know. So we just added it to globals.